### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer require imsus/laravel-imgproxy
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --tag="laravel-imgproxy-config"
+php artisan vendor:publish --tag="imgproxy-config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
If this is not intentional, i.e., you want it to be "laravel-imgproxy-config" and not "imgproxy-config" as it currently is set in your provider, you should change that there.

I'm not sure how this works with spatie/laravel-package-tools, but it is mostly a useless layer of abstraction anyway. Why not ditch it?