### PR TITLE
Support s3:// source URLs

### DIFF
--- a/src/ImgProxy.php
+++ b/src/ImgProxy.php
@@ -5,6 +5,7 @@ namespace Imsus\ImgProxy;
 use Imsus\ImgProxy\Enums\OutputExtension;
 use Imsus\ImgProxy\Enums\ResizeType;
 use Imsus\ImgProxy\Enums\SourceUrlMode;
+use InvalidArgumentException;
 
 class ImgProxy
 {


### PR DESCRIPTION
### Problem
`validateSourceUrl()` currently uses `FILTER_VALIDATE_URL`, which does not accept
the `s3://` scheme. Because of this, valid S3 sources like
`s3://bucket/path/to/image.webp` are treated as invalid and `build()` returns the
original source URL instead of generating an imgproxy URL.

This prevents using imgproxy with S3-compatible storage (AWS S3, DigitalOcean
Spaces, MinIO, etc.) via the `s3://` protocol.

### Solution
- Explicitly allow the `s3` scheme in `validateSourceUrl()`
- Keep existing strict validation for `http` and `https`
- No breaking changes for current behavior

### Example
```php
imgproxy('s3://files.yoomarket/path/to/image.webp')
    ->setWidth(432)
    ->build();
