### PR TITLE
feat: add Builder::toStorage() to materialize processed images onto Storage disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- New terminal `Builder::toStorage($disk, $path, $options)` fetches the processed image from imgproxy and streams it to a Storage disk, returning a `StoredImage` representation (disk, path, name, `url()` with public/private detection, adapter). Non-2xx responses and failed writes throw `ImgproxyStorageException`.
+- New `Builder::toStorage($disk, $path, $options)` terminal method fetches the processed image from imgproxy and streams it to a Storage disk, returning a `StoredImage` (disk, path, name, `url()` with public/private detection, adapter). Non-2xx responses and failed writes throw `ImgproxyStorageException`.
 
 ## [v2.0.0](https://github.com/imsus/laravel-imgproxy/compare/v1.1.0...v2.0.0) - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## [Unreleased]
+## [v2.1.0](https://github.com/imsus/laravel-imgproxy/compare/v2.0.0...v2.1.0)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## [Unreleased]
+
+### Enhancements
+
+- New terminal `Builder::toStorage($disk, $path, $options)` fetches the processed image from imgproxy and streams it to a Storage disk, returning a `StoredImage` representation (disk, path, name, `url()` with public/private detection, adapter). Non-2xx responses and failed writes throw `ImgproxyStorageException`.
+
 ## [v2.0.0](https://github.com/imsus/laravel-imgproxy/compare/v1.1.0...v2.0.0) - 2026-08-09
 
 ### Breaking changes

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,5 +17,5 @@ A processed image that has been fetched from imgproxy and written to a destinati
 _Avoid_: Cached image, saved url, stored url
 
 **Destination disk**:
-The Storage disk a stored image is written to, and the path on it the image occupies.
+The Storage disk a stored image is written to, and the path it occupies on that disk.
 _Avoid_: Storage, target, bucket

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Laravel imgproxy
+
+Terms for generating URLs that point at an imgproxy server and for persisting the processed images that server produces.
+
+## Language
+
+**Source**:
+The original image, referenced by URL or by a Storage disk and path, that imgproxy fetches and processes.
+_Avoid_: Original, input, raw image
+
+**imgproxy URL**:
+The signed, processed-image URL the builder derives from a source and a set of processing options. It is always recomputed on demand and never persisted.
+_Avoid_: Generated url, image url
+
+**Stored image**:
+A processed image that has been fetched from imgproxy and written to a destination disk by the `toStorage` operation.
+_Avoid_: Cached image, saved url, stored url
+
+**Destination disk**:
+The Storage disk a stored image is written to, and the path on it the image occupies.
+_Avoid_: Storage, target, bucket

--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ Storage::disk('s3')->imgproxy('products/image.jpg', 3600)
     ->url();
 ```
 
+### Materializing Processed Images
+
+Instead of returning a URL, `toStorage()` fetches the processed image from imgproxy and writes it to any Storage disk, returning a `StoredImage` representation of the stored file:
+
+```php
+$image = imgproxy()->image('https://example.com/photo.jpg')
+    ->width(800)
+    ->format(Format::Webp)
+    ->toStorage('s3', 'processed/photo.webp', ['visibility' => 'public']);
+
+$image->disk();      // 's3'
+$image->path();      // 'processed/photo.webp'
+$image->url();       // public disk -> https://.../processed/photo.webp
+$image->url(3600);   // private disk -> pre-signed temporaryUrl(), 1 hour
+$image->adapter();   // the destination disk adapter
+```
+
+The response body is streamed to the disk, so large images never load fully into memory. An existing file at the path is overwritten. When imgproxy responds with a non-success status or the disk write fails, an `ImgproxyStorageException` is thrown. On private destination disks, `url()` yields a pre-signed `temporaryUrl()` (5 minutes by default).
+
 ## Blade Components
 
 The package ships two Blade components: `<x-imgproxy-img>` for a single `<img>` with responsive srcsets, and `<x-imgproxy-picture>` for format negotiation with a fallback image. Both support LQIP placeholders, width or DPR candidates, named presets, lazy loading by default, and Storage disk sources:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $image->url(3600);   // private disk -> pre-signed temporaryUrl(), 1 hour
 $image->adapter();   // the destination disk adapter
 ```
 
-The response body is streamed to the disk, so large images never load fully into memory. An existing file at the path is overwritten. When imgproxy responds with a non-success status or the disk write fails, an `ImgproxyStorageException` is thrown. On private destination disks, `url()` yields a pre-signed `temporaryUrl()` (5 minutes by default).
+The response body is streamed to the disk, so large images never load fully into memory. An existing file at the path is overwritten. When imgproxy responds with a non-2xx status or the disk write fails, an `ImgproxyStorageException` is thrown. On private destination disks, `url()` yields a pre-signed `temporaryUrl()` (5 minutes by default).
 
 ## Blade Components
 

--- a/docs/adr/0001-toStorage-materialization.md
+++ b/docs/adr/0001-toStorage-materialization.md
@@ -1,0 +1,17 @@
+# Materialize processed images onto Storage disks with `toStorage()`
+
+The builder gained a terminal `toStorage(disk, path, options)` operation that fetches the processed image from imgproxy and writes it to a Laravel Storage disk, returning a `StoredImage` representation, instead of only ever producing imgproxy URLs on demand.
+
+**Why:** some applications want the processed artifact persisted in their own storage — durable copies that survive imgproxy instance changes, key rotation, or the 5-minute expiry of pre-signed private-disk source URLs — and want a plain object URL to serve from their CDN or storage directly.
+
+**Considered and rejected:**
+
+- **URL caching** — regenerate-and-reuse the URL string. Rejected: URL generation is deterministic and costs microseconds; for private-disk sources the stored URL embeds a pre-signed `temporaryUrl()` that expires, so caching the string is a correctness trap.
+- **Recipe persistence** — store source + options, regenerate later. Rejected: the user's need is a durable artifact and a stable address, not deferred generation.
+- **Returning the raw disk adapter** — rejected in favor of a `StoredImage` value object that carries disk + path and resolves URLs lazily (plain `url()` on public disks, pre-signed `temporaryUrl()` on private ones).
+
+**Consequences:**
+
+- The imgproxy response body is streamed to the disk (`Http` with the `stream` option, `writeStream`); large images never load fully into memory.
+- Non-2xx responses throw `ImgproxyStorageException` before any disk write; write failures are wrapped in the same exception with the original error preserved.
+- Existing files at the destination path are silently overwritten; a failed mid-stream write can leave a partial object (no atomic rename on object stores) — retries are self-healing.

--- a/docs/guide/storage-integration.md
+++ b/docs/guide/storage-integration.md
@@ -116,3 +116,49 @@ $url = imgproxy()->image('unused')
     ->width(800)
     ->url();
 ```
+
+## Materializing Processed Images
+
+`toStorage()` is the terminal opposite of `url()`: it fetches the processed image from imgproxy and writes it to a destination disk, returning a `StoredImage` representation of the stored file.
+
+```php
+use Imsus\LaravelImgproxy\Enums\Format;
+
+$image = imgproxy()->image('https://example.com/photo.jpg')
+    ->width(800)
+    ->format(Format::Webp)
+    ->toStorage('s3', 'processed/photo.webp');
+```
+
+The imgproxy URL is built from the current source and processing options; the response body is streamed to the disk, so large images never load fully into memory. An existing file at the destination path is overwritten. Extra write options (visibility, Content-Type, metadata) pass through to the disk write:
+
+```php
+$image = imgproxy()->image('https://example.com/photo.jpg')
+    ->toStorage('s3', 'processed/photo.webp', ['visibility' => 'public']);
+```
+
+The returned `StoredImage` carries the disk and path, and produces URLs with the same public/private rule as sources:
+
+```php
+$image->disk();    // 's3'
+$image->path();    // 'processed/photo.webp'
+$image->name();    // 'photo.webp'
+
+// Public destination disk -> plain object URL
+$image->url();
+
+// Private destination disk -> pre-signed temporaryUrl(), 5 minutes by default
+$image->url(3600);
+
+// The destination disk adapter, for advanced operations
+$image->adapter()->delete($image->path());
+```
+
+`(string) $image` is the same URL, so stored images work directly in Blade: `{{ $image }}`.
+
+### Failure behavior
+
+- When imgproxy responds with a non-success status (anything outside 2xx, including redirects), an `ImgproxyStorageException` is thrown **before** any disk write, with the HTTP status and a snippet of the response body in the message.
+- When the disk write fails, the original error is wrapped in the same exception type. This covers both throwing disks and disks configured with `'throw' => false`, which report failures by returning `false` instead.
+- The destination disk must exist; a missing disk throws Laravel's usual `InvalidArgumentException` before any HTTP request is made.
+- The fetch uses a 30-second timeout that covers the whole request, including the streamed body transfer; for very large renders or slow links, raise it via `Http::timeout()` configuration on the request or the HTTP client defaults.

--- a/docs/guide/storage-integration.md
+++ b/docs/guide/storage-integration.md
@@ -119,7 +119,7 @@ $url = imgproxy()->image('unused')
 
 ## Materializing Processed Images
 
-`toStorage()` is the terminal opposite of `url()`: it fetches the processed image from imgproxy and writes it to a destination disk, returning a `StoredImage` representation of the stored file.
+`toStorage()` is the terminal counterpart of `url()`: instead of returning a URL, it fetches the processed image from imgproxy and writes it to a destination disk, returning a `StoredImage` representation of the stored file.
 
 ```php
 use Imsus\LaravelImgproxy\Enums\Format;

--- a/docs/guide/storage-integration.md
+++ b/docs/guide/storage-integration.md
@@ -162,3 +162,66 @@ $image->adapter()->delete($image->path());
 - When the disk write fails, the original error is wrapped in the same exception type. This covers both throwing disks and disks configured with `'throw' => false`, which report failures by returning `false` instead.
 - The destination disk must exist; a missing disk throws Laravel's usual `InvalidArgumentException` before any HTTP request is made.
 - The fetch uses a 30-second timeout that covers the whole request, including the streamed body transfer; for very large renders or slow links, raise it via `Http::timeout()` configuration on the request or the HTTP client defaults.
+
+## Use Cases
+
+### Converting images between storages
+
+The storage-to-storage pipeline: the raw image stays on its origin disk, imgproxy converts it, and the result is written to a different disk:
+
+::: tip
+imgproxy is a conversion tool that *serves* the processed bytes — it has no feature to upload results to your storage. `toStorage()` is the bridge: it fetches the converted output and persists it, so imgproxy acts as a pure conversion service in the middle of your pipeline.
+:::
+
+```php
+use Imsus\LaravelImgproxy\Enums\Format;
+use Imsus\LaravelImgproxy\Enums\ResizeType;
+
+$image = Storage::disk('origin')->imgproxy('raw/photo.jpg')
+    ->resize(ResizeType::Fill, 800, 600)
+    ->format(Format::Webp)
+    ->toStorage('processed', 'converted/photo.webp');
+
+$image->url(); // serve from the processed disk
+```
+
+### Materializing variants at upload time
+
+Generate format and size variants once, when the original is uploaded, instead of converting on every request. The stored images are durable — they survive imgproxy instance changes and key rotation, and imgproxy never sits in the request path afterward:
+
+```php
+use Imsus\LaravelImgproxy\Enums\Format;
+
+foreach ([300, 600, 1200] as $width) {
+    Storage::disk('origin')->imgproxy('raw/photo.jpg')
+        ->width($width)
+        ->format(Format::Webp)
+        ->toStorage('cdn', "variants/photo-{$width}.webp", ['visibility' => 'public']);
+}
+```
+
+### Batch conversion with queued jobs
+
+`toStorage()` is synchronous — one conversion per call, blocking until the bytes are written. For large batches, run the conversions in queued jobs:
+
+::: warning
+Do **not** build the source URL before queueing a job. A private origin disk yields a pre-signed source URL that expires (5 minutes by default); a job that runs later fetches an expired source and fails. Resolve the disk inside the job instead, so the pre-signed URL is fresh at run time.
+:::
+
+```php
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Storage;
+use Imsus\LaravelImgproxy\Enums\Format;
+
+class ConvertImageJob implements ShouldQueue
+{
+    public function __construct(private readonly string $path) {}
+
+    public function handle(): void
+    {
+        Storage::disk('origin')->imgproxy($this->path)
+            ->format(Format::Webp)
+            ->toStorage('processed', 'converted/'.$this->path.'.webp');
+    }
+}
+```

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,12 +6,15 @@ namespace Imsus\LaravelImgproxy;
 
 use BackedEnum;
 use DateTimeInterface;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Imsus\LaravelImgproxy\Enums\Format;
 use Imsus\LaravelImgproxy\Enums\Gravity;
 use Imsus\LaravelImgproxy\Enums\ResizeType;
 use Imsus\LaravelImgproxy\Enums\WatermarkPosition;
+use Imsus\LaravelImgproxy\Exceptions\ImgproxyStorageException;
 use InvalidArgumentException;
+use Throwable;
 use ValueError;
 
 /**
@@ -32,6 +35,11 @@ final class Builder
 {
     /** @var list<string> */
     private const array ENCODINGS = ['base64', 'plain'];
+
+    /**
+     * The HTTP timeout, in seconds, for fetching the processed image in toStorage().
+     */
+    private const int TO_STORAGE_TIMEOUT_SECONDS = 30;
 
     private readonly UrlSigner $signer;
 
@@ -74,6 +82,46 @@ final class Builder
     public function __toString(): string
     {
         return $this->url();
+    }
+
+    /**
+     * Fetch the processed image from imgproxy and write it to a Storage disk.
+     *
+     * The imgproxy URL is built from the current source and processing
+     * options; the response body is streamed to the destination disk, so
+     * large images never load fully into memory. An existing file at the
+     * path is overwritten. Returns a representation of the stored image;
+     * public destination disks yield plain URLs, private ones pre-signed
+     * temporary URLs.
+     *
+     * @param  array<string, mixed>  $options  Extra options forwarded to the disk write, e.g. visibility or Content-Type.
+     *
+     * @throws InvalidArgumentException When the destination disk is not configured.
+     * @throws ImgproxyStorageException When imgproxy responds with a non-success status or the disk write fails.
+     */
+    public function toStorage(string $disk, string $path, array $options = []): StoredImage
+    {
+        $adapter = Storage::disk($disk);
+
+        $response = Http::timeout(self::TO_STORAGE_TIMEOUT_SECONDS)
+            ->withOptions(['stream' => true])
+            ->get($this->url());
+
+        if (! $response->successful()) {
+            throw ImgproxyStorageException::fromResponse($this->url(), $response);
+        }
+
+        try {
+            $written = $adapter->writeStream($path, $response->resource(), $options);
+        } catch (Throwable $exception) {
+            throw ImgproxyStorageException::fromWrite($disk, $path, $exception);
+        }
+
+        if (! $written) {
+            throw ImgproxyStorageException::fromWrite($disk, $path);
+        }
+
+        return new StoredImage($disk, $path);
     }
 
     /**

--- a/src/DiskUrl.php
+++ b/src/DiskUrl.php
@@ -8,11 +8,12 @@ use DateTimeInterface;
 use Illuminate\Filesystem\FilesystemAdapter;
 
 /**
- * Resolves a Storage disk path to an imgproxy source URL.
+ * Resolves a Storage disk path to a URL: the plain url() on public disks, a
+ * pre-signed temporaryUrl() on private ones. Shared by imgproxy source
+ * resolution and stored-image URL resolution.
  *
  * A disk is treated as private when its driver can produce temporary URLs
- * and its config does not mark it public; private disks yield a pre-signed
- * temporary URL, public disks yield their plain URL.
+ * and its config does not mark it public.
  */
 final class DiskUrl
 {
@@ -22,6 +23,8 @@ final class DiskUrl
     private const int DEFAULT_EXPIRATION_SECONDS = 300;
 
     /**
+     * Resolve a disk path to a URL, pre-signing it on private disks.
+     *
      * @param  int|DateTimeInterface|null  $expiration  Temporary URL lifetime in seconds from now, an absolute time, or null for the default 5 minutes.
      */
     public static function resolve(FilesystemAdapter $disk, string $path, int|DateTimeInterface|null $expiration = null): string

--- a/src/Exceptions/ImgproxyStorageException.php
+++ b/src/Exceptions/ImgproxyStorageException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imsus\LaravelImgproxy\Exceptions;
+
+use Illuminate\Http\Client\Response;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a processed image cannot be fetched from imgproxy or written
+ * to a destination disk.
+ */
+final class ImgproxyStorageException extends RuntimeException
+{
+    /**
+     * The exception for a non-successful imgproxy response. The message
+     * carries the HTTP status, the requested URL, and a snippet of the body.
+     */
+    public static function fromResponse(string $url, Response $response): self
+    {
+        $body = mb_substr((string) $response->body(), 0, 200);
+
+        return new self("imgproxy responded with HTTP {$response->status()} for [{$url}]: {$body}");
+    }
+
+    /**
+     * The exception for a failed write to the destination disk, preserving
+     * the original write error when one was raised (disks configured with
+     * "throw" => false report failures by returning false instead).
+     */
+    public static function fromWrite(string $disk, string $path, ?Throwable $previous = null): self
+    {
+        $reason = $previous?->getMessage() ?? 'the disk did not report an error';
+
+        return new self(
+            "Failed to store the processed image on disk [{$disk}] at [{$path}]: {$reason}",
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/StoredImage.php
+++ b/src/StoredImage.php
@@ -12,8 +12,9 @@ use Illuminate\Support\Facades\Storage;
  * A processed image that has been fetched from imgproxy and written to a
  * destination disk by Builder::toStorage().
  *
- * Immutable, and holds only the disk name and path so it can be serialized
- * and passed around; the disk adapter and URLs are resolved lazily.
+ * It is immutable and holds only the disk name and path, so it is
+ * serializable and cheap to pass around; the disk adapter and URLs
+ * resolve lazily.
  */
 final class StoredImage
 {

--- a/src/StoredImage.php
+++ b/src/StoredImage.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imsus\LaravelImgproxy;
+
+use DateTimeInterface;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A processed image that has been fetched from imgproxy and written to a
+ * destination disk by Builder::toStorage().
+ *
+ * Immutable, and holds only the disk name and path so it can be serialized
+ * and passed around; the disk adapter and URLs are resolved lazily.
+ */
+final class StoredImage
+{
+    public function __construct(
+        private readonly string $disk,
+        private readonly string $path,
+    ) {}
+
+    /**
+     * The name of the destination disk.
+     */
+    public function disk(): string
+    {
+        return $this->disk;
+    }
+
+    /**
+     * The path of the stored image on the destination disk.
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * The file name of the stored image.
+     */
+    public function name(): string
+    {
+        return basename($this->path);
+    }
+
+    /**
+     * The destination disk adapter.
+     */
+    public function adapter(): FilesystemAdapter
+    {
+        return Storage::disk($this->disk);
+    }
+
+    /**
+     * A URL for the stored image: the plain object URL on public disks, a
+     * pre-signed temporary URL on private disks.
+     *
+     * @param  int|DateTimeInterface|null  $expiration  Temporary URL lifetime in seconds from now, an absolute time, or null for the default 5 minutes.
+     */
+    public function url(int|DateTimeInterface|null $expiration = null): string
+    {
+        return DiskUrl::resolve($this->adapter(), $this->path, $expiration);
+    }
+
+    /**
+     * The stored image URL, for use in Blade and string contexts.
+     */
+    public function __toString(): string
+    {
+        return $this->url();
+    }
+}

--- a/tests/Feature/ImgproxyToStorageTest.php
+++ b/tests/Feature/ImgproxyToStorageTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Imsus\LaravelImgproxy\Exceptions\ImgproxyStorageException;
+use Imsus\LaravelImgproxy\StoredImage;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+afterEach(function () {
+    Carbon::setTestNow();
+
+    Storage::disk('public')->deleteDirectory('processed');
+    Storage::disk('public')->delete('blocked');
+    Storage::disk('local')->deleteDirectory('processed');
+
+    if (config('filesystems.disks.quiet') !== null) {
+        Storage::disk('quiet')->delete('blocked');
+    }
+});
+
+beforeEach(function () {
+    config()->set('laravel-imgproxy', [
+        'default' => 'default',
+        'instances' => [
+            'default' => [
+                'url' => 'https://imgproxy.example.com',
+                'key' => null,
+                'salt' => null,
+                'signature_size' => null,
+                'encoding' => 'base64',
+            ],
+        ],
+        'presets' => [],
+    ]);
+
+    config()->set('filesystems.disks.public.url', 'https://cdn.example.com');
+});
+
+it('fetches the processed image and stores it on a public disk', function () {
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    $image = imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->width(300)
+        ->toStorage('public', 'processed/photo.webp');
+
+    expect($image)->toBeInstanceOf(StoredImage::class)
+        ->and($image->disk())->toBe('public')
+        ->and($image->path())->toBe('processed/photo.webp')
+        ->and($image->name())->toBe('photo.webp')
+        ->and($image->adapter())->toBe(Storage::disk('public'))
+        ->and(Storage::disk('public')->get('processed/photo.webp'))->toBe('image-bytes');
+
+    Http::assertSent(fn (Request $request) => $request->url() === 'https://imgproxy.example.com/unsafe/w:300/aHR0cHM6Ly9jZG4uZXhhbXBsZS5jb20vaW1hZ2VzL3Bob3RvLmpwZw');
+});
+
+it('extracts the file name from a nested destination path', function () {
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    $image = imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'processed/2026/photo.webp');
+
+    expect($image->name())->toBe('photo.webp')
+        ->and($image->url())->toBe('https://cdn.example.com/processed/2026/photo.webp');
+});
+
+it('overwrites an existing file at the destination path', function () {
+    Storage::disk('public')->put('processed/photo.webp', 'old-bytes');
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('new-bytes', 200),
+    ]);
+
+    imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'processed/photo.webp');
+
+    expect(Storage::disk('public')->get('processed/photo.webp'))->toBe('new-bytes');
+});
+
+it('throws without writing when imgproxy responds with a non-success status', function () {
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('Not Found', 404),
+    ]);
+
+    expect(fn () => imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'processed/photo.webp'))
+        ->toThrow(ImgproxyStorageException::class, 'HTTP 404')
+        ->and(Storage::disk('public')->exists('processed/photo.webp'))->toBeFalse();
+});
+
+it('wraps a failed disk write in the storage exception', function () {
+    Storage::disk('public')->put('blocked', 'a file blocking the directory');
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    expect(fn () => imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'blocked/photo.webp'))
+        ->toThrow(ImgproxyStorageException::class, 'public');
+});
+
+it('throws when the write fails on a disk that reports failures instead of throwing', function () {
+    config()->set('filesystems.disks.quiet', [
+        'driver' => 'local',
+        'root' => storage_path('app/quiet'),
+        'throw' => false,
+    ]);
+
+    Storage::disk('quiet')->put('blocked', 'a file blocking the directory');
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    expect(fn () => imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('quiet', 'blocked/photo.webp'))
+        ->toThrow(ImgproxyStorageException::class, 'quiet');
+});
+
+it('throws without writing when imgproxy responds with a redirect', function () {
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('Moved Permanently', 301),
+    ]);
+
+    expect(fn () => imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'processed/photo.webp'))
+        ->toThrow(ImgproxyStorageException::class, 'HTTP 301')
+        ->and(Storage::disk('public')->exists('processed/photo.webp'))->toBeFalse();
+});
+
+it('forwards extra write options to the disk write', function () {
+    Storage::extend('recording', function ($app, array $config) {
+        $adapter = new LocalFilesystemAdapter($config['root']);
+
+        return new RecordingFilesystemAdapter(new Filesystem($adapter), $adapter, $config);
+    });
+
+    config()->set('filesystems.disks.recording', [
+        'driver' => 'recording',
+        'root' => storage_path('app/recording'),
+    ]);
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('recording', 'processed/photo.webp', ['visibility' => 'public']);
+
+    expect(Storage::disk('recording')->lastWriteOptions)->toBe(['visibility' => 'public']);
+});
+
+it('throws when the destination disk is not configured', function () {
+    imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('missing', 'processed/photo.webp');
+})->throws(InvalidArgumentException::class, 'Disk [missing]');
+
+it('yields a plain url on a public destination disk', function () {
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    $image = imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('public', 'processed/photo.webp');
+
+    expect($image->url())->toBe('https://cdn.example.com/processed/photo.webp')
+        ->and((string) $image)->toBe('https://cdn.example.com/processed/photo.webp');
+});
+
+it('yields a pre-signed url with the given expiration on a private destination disk', function () {
+    Carbon::setTestNow('2026-01-01 00:00:00+00:00');
+
+    Storage::disk('local')->buildTemporaryUrlsUsing(
+        fn (string $path, $expiration, array $options = []): string => 'https://signed.example.com/'.$path.'?expires='.$expiration->getTimestamp(),
+    );
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    $image = imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('local', 'processed/photo.webp');
+
+    expect($image->url(3600))->toBe('https://signed.example.com/processed/photo.webp?expires=1767229200');
+});
+
+it('defaults a private destination url to a five minute expiration', function () {
+    Carbon::setTestNow('2026-01-01 00:00:00+00:00');
+
+    Storage::disk('local')->buildTemporaryUrlsUsing(
+        fn (string $path, $expiration, array $options = []): string => 'https://signed.example.com/'.$path.'?expires='.$expiration->getTimestamp(),
+    );
+
+    Http::fake([
+        'https://imgproxy.example.com/*' => Http::response('image-bytes', 200),
+    ]);
+
+    $image = imgproxy()->image('https://cdn.example.com/images/photo.jpg')
+        ->toStorage('local', 'processed/photo.webp');
+
+    expect($image->url())->toBe('https://signed.example.com/processed/photo.webp?expires=1767225900');
+});
+
+/**
+ * A disk adapter that records the options of the last write, for asserting
+ * that toStorage forwards its options to the disk write.
+ */
+final class RecordingFilesystemAdapter extends FilesystemAdapter
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $lastWriteOptions = [];
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function writeStream($path, $resource, array $options = []): bool
+    {
+        $this->lastWriteOptions = $options;
+
+        return parent::writeStream($path, $resource, $options);
+    }
+}

--- a/tests/Feature/ImgproxyToStorageTest.php
+++ b/tests/Feature/ImgproxyToStorageTest.php
@@ -86,7 +86,7 @@ it('overwrites an existing file at the destination path', function () {
     expect(Storage::disk('public')->get('processed/photo.webp'))->toBe('new-bytes');
 });
 
-it('throws without writing when imgproxy responds with a non-success status', function () {
+it('throws without writing when imgproxy responds with a non-2xx status', function () {
     Http::fake([
         'https://imgproxy.example.com/*' => Http::response('Not Found', 404),
     ]);
@@ -138,7 +138,7 @@ it('throws without writing when imgproxy responds with a redirect', function () 
         ->and(Storage::disk('public')->exists('processed/photo.webp'))->toBeFalse();
 });
 
-it('forwards extra write options to the disk write', function () {
+it('forwards extra write options to the disk', function () {
     Storage::extend('recording', function ($app, array $config) {
         $adapter = new LocalFilesystemAdapter($config['root']);
 
@@ -194,7 +194,7 @@ it('yields a pre-signed url with the given expiration on a private destination d
     expect($image->url(3600))->toBe('https://signed.example.com/processed/photo.webp?expires=1767229200');
 });
 
-it('defaults a private destination url to a five minute expiration', function () {
+it('uses a five-minute default expiration for a private destination url', function () {
     Carbon::setTestNow('2026-01-01 00:00:00+00:00');
 
     Storage::disk('local')->buildTemporaryUrlsUsing(


### PR DESCRIPTION
## Summary

Adds `Builder::toStorage()`, a new terminal operation that materializes the processed image onto a Storage disk — the storage → imgproxy → storage conversion pipeline. Instead of returning an imgproxy URL, it fetches the processed bytes and persists them, returning a `StoredImage` representation.

Targets **v2.1.0**.

## API

```php
$image = imgproxy()->image('https://example.com/photo.jpg')
    ->width(800)
    ->format(Format::Webp)
    ->toStorage('s3', 'processed/photo.webp', ['visibility' => 'public']);

$image->disk();      // 's3'
$image->path();      // 'processed/photo.webp'
$image->name();      // 'photo.webp'
$image->url();       // public disk -> plain url(); private disk -> pre-signed temporaryUrl() (5 min default)
$image->adapter();   // destination disk adapter
(string) $image;     // same as url()
```

## Behavior

- Fetches via the `Http` facade with the response body **streamed** to `writeStream` — large images never load fully into memory.
- Non-2xx responses (including redirects) throw `ImgproxyStorageException` **before** any disk write, with status + body snippet in the message.
- Failed writes throw the same exception — covering both throwing disks and disks configured with `'throw' => false` that report failure by returning `false`.
- Existing files at the destination path are overwritten.
- Extra `$options` (visibility, Content-Type, metadata) are forwarded to the disk write.
- Public/private URL detection reuses the existing `DiskUrl` rule, so `StoredImage::url()` matches how sources behave.

## Docs

- `docs/guide/storage-integration.md` — Materializing section + Use Cases (storage-to-storage conversion, upload-time variants, queued batch conversion with a warning about expiring pre-signed sources).
- `README.md` — Materializing subsection.
- `docs/adr/0001-toStorage-materialization.md` — decision record (materialize vs. URL caching vs. recipe persistence).
- `CONTEXT.md` — new glossary (stored image, destination disk).
- `CHANGELOG.md` — v2.1.0 entry.

## Validation

- `composer test`: 197 tests, 195 passed, 2 env-gated live-imgproxy skips
- `composer lint:check` clean, `composer analyse` clean, 100% type coverage

## Notes

- Additive change; no breaking changes.
- Known edge (documented): a failed mid-stream write can leave a partial object — accepted, overwrite semantics make retries self-healing (no atomic rename on object stores).
